### PR TITLE
Update README.md: environment variable name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ You can "activate" the environment with
 ```
 source activate mykameleon
 ```
-which will prepend *path/to/miniconda2/envs/mykameleon/bin* to **PATH**, set the environment variable **CONDA_ENV_PATH**, and prepend your prompt with **(mykameleon)**. 
+which will prepend *path/to/miniconda2/envs/mykameleon/bin* to **PATH**, set the environment variable **CONDA_PREFIX**, and prepend your prompt with **(mykameleon)**. 
 
 
 This allows you to run kameleon's version of python without writing out the full path. For example, we can print the help documentation for the ionosphere visualizer like this:
 ```
-(mykameleon)$ cd $CONDA_ENV_PATH/bin/ccmc/examples/python
+(mykameleon)$ cd $CONDA_PREFIX/bin/ccmc/examples/python
 (mykameleon)$ python ionosphere_test.py -h
 ```
 


### PR DESCRIPTION
On mac, my environment variable was named "$CONDA_PREFIX" instead of "$CONDA_ENV_PATH".  My installer was the Miniconda Python 2.7 for Mac (Miniconda2-latest-MacOSX-x86_64.sh).
```
(mykameleon) gs674-boblitmbp:kameleon jboblit1$ echo $CONDA_ENV_PATH

(mykameleon) gs674-boblitmbp:kameleon jboblit1$ echo $CONDA_PREFIX
/Users/jboblit1/miniconda2/envs/mykameleon
(mykameleon) gs674-boblitmbp:kameleon jboblit1$ cd $CONDA_PREFIX/bin/ccmc/examples/python
(mykameleon) gs674-boblitmbp:python jboblit1$ pwd
/Users/jboblit1/miniconda2/envs/mykameleon/bin/ccmc/examples/python
```